### PR TITLE
Update DataExploration/src/ExploreCaloDigis_module.cc

### DIFF
--- a/DataExploration/fcl/Ex01.fcl
+++ b/DataExploration/fcl/Ex01.fcl
@@ -5,21 +5,15 @@ process_name : ExploreStrawDigis
 
 source : { module_type : RootInput }
 
-services : @local::Services.Reco
-services.TFileService.fileName : "ExploreStrawDigis.root"
-
-physics :
-{
-  producers : {} 
+physics : {
   analyzers : {
     ESD : {
-      module_type : ExploreStrawDigis
-      StrawDigis : SelectRecoMC
+      module_type   : ExploreStrawDigis
+      StrawDigisTag : SelectRecoMC
     }
   }
 
-  MyTrigPath : []
   MyEndPath : [ ESD ]
 }
 
-
+services.TFileService.fileName : "out/ExploreStrawDigis.root"

--- a/DataExploration/fcl/Ex02a.fcl
+++ b/DataExploration/fcl/Ex02a.fcl
@@ -1,0 +1,31 @@
+#include "Offline/fcl/minimalMessageService.fcl"
+#include "Offline/fcl/standardServices.fcl"
+
+process_name: CaloTutorial
+
+source: {
+   module_type: RootInput
+   maxEvents : 500
+}
+
+services : @local::Services.Core
+
+physics :
+{
+    analyzers:
+    {
+       DumpCaloDigis:
+       {
+            module_type    : ExploreCaloDigis
+            CaloDigis      : SelectRecoMC
+            CaloClusters   : CaloClusterMaker
+            runExercise    : true
+        }
+     }
+
+    end1: [DumpCaloDigis]
+
+    end_paths:     [end1]
+}
+
+services.TFileService.fileName : "out/ExploreCaloDigis.root"

--- a/DataExploration/src/ExploreCaloDigis_module.cc
+++ b/DataExploration/src/ExploreCaloDigis_module.cc
@@ -58,7 +58,7 @@ namespace mu2e {
        float  cluEnergy_[arrayDim],cluTime_[arrayDim],cluCogX_[arrayDim],cluCogY_[arrayDim],cluCogZ_[arrayDim],cluE1_[arrayDim],cluE9_[arrayDim],cluE25_[arrayDim],clu2ndMoment_[arrayDim];
        std::vector<std::vector<int> > cluCrystalList_;
 
-       TH1F *crystalEnergy_        = nullptr;
+       TH1F *crystalADCSum_        = nullptr;
        TH1F *crystalTime_          = nullptr;
        TH1F *clusterMaxCrystalHit_ = nullptr;
        TH1F *clusterEnergyHigh_    = nullptr;
@@ -104,7 +104,7 @@ namespace mu2e {
        Ntup_->Branch("cluCrystalList", &cluCrystalList_);
 
 
-       crystalEnergy_        = tfs->make<TH1F>("cryHitEnergy",         "Sum of ADC values in each digi waveform", 100,   0., 25000. );
+       crystalADCSum_        = tfs->make<TH1F>("cryADCSum",            "Sum of ADC values in digi waveform",      100,   0., 25000. );
        crystalTime_          = tfs->make<TH1F>("cryHitTime",           "Time of crystal hit",                     100,   0.,  2000. );
        clusterEnergyHigh_    = tfs->make<TH1F>("clusterEnergyHigh",    "Cluster energy radius > 400",             150,   0.,   150. );
        clusterMaxCrystalHit_ = tfs->make<TH1F>("clusterMaxCrystalHit", "Energy most energetic hit in cluster",    100,   0.,    50. );
@@ -192,7 +192,7 @@ namespace mu2e {
 	     int et = 0;
 	     for(auto e: digi.waveform()) et += e;
 
-	     crystalEnergy_->Fill(et);
+	     crystalADCSum_->Fill(et);
 	     crystalTime_->Fill(digi.t0());
            }
 

--- a/DataExploration/src/ExploreStrawDigis_module.cc
+++ b/DataExploration/src/ExploreStrawDigis_module.cc
@@ -2,19 +2,17 @@
 //  ExploreStrawDigis module.  Examine features of StrawDigi
 //
 
-// C++ includes.
-#include <iostream>
+#include "Offline/RecoDataProducts/inc/StrawDigi.hh"
+#include "Offline/RecoDataProducts/inc/ComboHit.hh"
 
-// Framework includes
 #include "art/Framework/Core/EDAnalyzer.h"
 #include "art/Framework/Core/ModuleMacros.h"
 #include "art/Framework/Principal/Event.h"
 #include "art_root_io/TFileService.h"
-// Root includes
+
 #include "TH1F.h"
-// Mu2e Data Products
-#include "Offline/RecoDataProducts/inc/StrawDigi.hh"
-#include "Offline/RecoDataProducts/inc/ComboHit.hh"
+
+#include <iostream>
 
 namespace mu2e {
 
@@ -24,42 +22,48 @@ namespace mu2e {
     struct Config {
       using Name=fhicl::Name;
       using Comment=fhicl::Comment;
-      fhicl::Atom<art::InputTag> SDCTag{Name("StrawDigis"), Comment("StrawDigiCollection"), art::InputTag()};
+      fhicl::Atom<art::InputTag> SDCTag{Name("StrawDigisTag"), Comment("Input tag for a StrawDigiCollection")};
     };
     typedef art::EDAnalyzer::Table<Config> Parameters;
 
     explicit ExploreStrawDigis(const Parameters& conf);
 
-    void analyze(const art::Event& event);
-    void beginJob( );
+    void beginJob( ) override;
+    void analyze(const art::Event& event) override;
 
   private:
-    Config _conf;
-    TH1F *_nstrawdigi, *_tdc, *_adc, *_tot, *_deltatdc;
+    art::ProductToken<StrawDigiCollection> const _strawDigisToken;
+
+    TH1F* _nstrawdigi = nullptr;
+    TH1F* _tdc        = nullptr;
+    TH1F* _adc        = nullptr;
+    TH1F* _tot        = nullptr;
+    TH1F* _deltatdc   = nullptr;
 
   };
 
   ExploreStrawDigis::ExploreStrawDigis(const Parameters& conf)
     : art::EDAnalyzer(conf),
-      _conf(conf()) {
-    consumes<StrawDigiCollection>(_conf.SDCTag());
+      _strawDigisToken{consumes<StrawDigiCollection>(conf().SDCTag())}
+  {
   }
 
   void ExploreStrawDigis::beginJob( ){
     art::ServiceHandle<art::TFileService> tfs;
-      _nstrawdigi = tfs->make<TH1F>("NStrawDigis","N StrawDigis",250,0,5000);
-      _tdc = tfs->make<TH1F>("tdc","StrawDigis TDC",100,0,100000); 
-      _deltatdc = tfs->make<TH1F>("deltatdc","StrawDigis deltatdc",100,-100,1000);
-      _tot = tfs->make<TH1F>("tot","StrawDigis TOT",100,0,100);
-      _adc = tfs->make<TH1F>("adc","StrawDigis ADC",100,0,5000);
-
+    _nstrawdigi = tfs->make<TH1F>("NStrawDigis", "N StrawDigis",        250,    0.,  5000.);
+    _tdc        = tfs->make<TH1F>("tdc",         "StrawDigis TDC",      100,    0.,100000.);
+    _deltatdc   = tfs->make<TH1F>("deltatdc",    "StrawDigis deltatdc", 100, -100.,  1000.);
+    _tot        = tfs->make<TH1F>("tot",         "StrawDigis TOT",      100,    0.,   100.);
+    _adc        = tfs->make<TH1F>("adc",         "StrawDigis ADC",      100,    0.,  5000.);
   }
 
   void ExploreStrawDigis::analyze(const art::Event& event){
-  // find the StrawDigi collection in the event
-    auto sdcH = event.getValidHandle<StrawDigiCollection>(_conf.SDCTag());
-    auto const& sdc = *sdcH;
+
+    // Get the requestedd StrawDigiCollection
+    auto const& sdc = event.getProduct( _strawDigisToken );
+
     _nstrawdigi->Fill(sdc.size());
+
     // loop over strawdigis
     for(auto const& sd : sdc) {
       _tdc->Fill(sd.TDC(StrawEnd::cal));
@@ -71,5 +75,4 @@ namespace mu2e {
 
 } // end namespace mu2e
 
-using mu2e::ExploreStrawDigis;
-DEFINE_ART_MODULE(ExploreStrawDigis)
+DEFINE_ART_MODULE(mu2e::ExploreStrawDigis)


### PR DESCRIPTION
I updated this module to current recommended practices.  I also fixed one issue: the histogram that was meant to be the crystal energy, in MeV, is actually the sum of the ADC counts.  I changed the name and title to match.

I have a question for Andy and Bertrand.  The example that runs this is DataExploration/fcl/Ex02.fcl .  This example runs the some producer modules before running the analyzer.  Is this an artifact of the way things were in 2019?  I would prefer to just run the analyzer on a file that has premade data products, such as the MDC2020 CeEndpointMix1BBSignal.MDC2020r_perfect_v1_0 dataset.  Any objections?  
